### PR TITLE
Fix compile warning for SM 1.7-1.9

### DIFF
--- a/scripting/nt_changeteams.sp
+++ b/scripting/nt_changeteams.sp
@@ -10,7 +10,7 @@ public Plugin myinfo = {
 	name = "NT Team join chat commands",
 	description = "Use !s, !j, !n, command to join Spectator, Jinrai and NSF teams respectively",
 	author = "bauxite, rain",
-	version = "2.0",
+	version = "2.0.1",
 	url = "https://discord.gg/afhZuFB9A5",
 };
 
@@ -32,8 +32,8 @@ int GetTeamOfChar(char c)
 		case 'j': return TEAM_JINRAI;
 		case 'n': return TEAM_NSF;
 		case 's': return TEAM_SPECTATOR;
-		default: return TEAM_NONE;
 	}
+	return TEAM_NONE;
 }
 
 public Action Cmd_Switch(int client, int args)


### PR DESCRIPTION
This is a fairly minor fix for the SM 1.7-1.9 compilers, which will incorrectly complain about the switch catchall default return.

This change fixes the following compiler warning for the 1.7-1.9 range:
> nt_changeteams.sp(37) : warning 209: function "GetTeamOfChar" should return a value